### PR TITLE
When max_selected == 1, unable to "deselect" the one selected friend. 

### DIFF
--- a/jquery.facebook.multifriend.select.js
+++ b/jquery.facebook.multifriend.select.js
@@ -154,9 +154,14 @@
                         return;
                     }
                     
-                // if the max is 1 then unselect the current and select the new    
+                // if the max is 1 and this is not already selected then unselect anything currently selected    
                 if(settings.max_selected == 1) {
-                    elem.find(".selected").removeClass("selected");                    
+                  jfmsAlreadySelected = elem.find(".selected");
+			if (jfmsAlreadySelected.attr('id') == $(this).attr('id')) {
+				//do nothing. $(this).toggleClass("selected"); below will remove selection
+			} else { 
+			    elem.find(".selected").removeClass("selected");
+			}
                 }
                     
                 $(this).toggleClass("selected");


### PR DESCRIPTION
Small logical bug around line 157 where all items were being de-selected, but then $(this).toggle right below it would reselect the item.  My minor fix probably isn't the most elegant, but it works.

p.s. - awesome work. saved me a millennium of hours.
