### PR TITLE
Login Status Failure

### DIFF
--- a/jquery.facebook.multifriend.select.js
+++ b/jquery.facebook.multifriend.select.js
@@ -73,31 +73,40 @@
 			preselected_friends_graph = arrayToObjectGraph(settings.pre_selected_friends),
 			excluded_friends_graph = arrayToObjectGraph(settings.exclude_friends),
             all_friends;
-            
-        FB.api('/me/friends?fields=' + settings.friend_fields, function(response) {
-            var sortedFriendData = response.data.sort(settings.sorter),
-                preselectedFriends = {},
-                buffer = [],
-			    selectedClass = "";
-            
-            $.each(sortedFriendData, function(i, friend) {
-				if(! (friend.id in excluded_friends_graph)) {
-					selectedClass = (friend.id in preselected_friends_graph) ? "selected" : "";
-	                buffer.push("<div class='jfmfs-friend " + selectedClass + " ' id='" + friend.id  +"'><img/><div class='friend-name'>" + friend.name + "</div></div>");            
-				}
-            });
-            friend_container.append(buffer.join(""));
-            
-            uninitializedImagefriendElements = $(".jfmfs-friend", elem);            
-            uninitializedImagefriendElements.bind('inview', function (event, visible) {
-                if( $(this).attr('src') === undefined) {
-                    $("img", $(this)).attr("src", "//graph.facebook.com/" + this.id + "/picture");
-                }
-                $(this).unbind('inview');
-            });
+        
+        this.getFriends = function() {
+          FB.api('/me/friends?fields=' + settings.friend_fields, function(response) {
+            if(typeof(response.data) == 'undefined') {
+              setTimeout(obj.getFriends, 500);
+              return;
+            }
+              var sortedFriendData = response.data.sort(settings.sorter),
+                  preselectedFriends = {},
+                  buffer = [],
+  			    selectedClass = "";
 
-            init();
-        });
+              $.each(sortedFriendData, function(i, friend) {
+  				if(! (friend.id in excluded_friends_graph)) {
+  					selectedClass = (friend.id in preselected_friends_graph) ? "selected" : "";
+  	                buffer.push("<div class='jfmfs-friend " + selectedClass + " ' id='" + friend.id  +"'><img/><div class='friend-name'>" + friend.name + "</div></div>");            
+  				}
+              });
+              friend_container.append(buffer.join(""));
+
+              uninitializedImagefriendElements = $(".jfmfs-friend", elem);            
+              uninitializedImagefriendElements.bind('inview', function (event, visible) {
+                  if( $(this).attr('src') === undefined) {
+                      $("img", $(this)).attr("src", "//graph.facebook.com/" + this.id + "/picture");
+                  }
+                  $(this).unbind('inview');
+              });
+
+              init();
+          });
+        }   
+        
+        this.getFriends(); 
+        
         
         
         // ----------+----------+----------+----------+----------+----------+----------+


### PR DESCRIPTION
I used the plugin in an app I'm building and if the user came to the app _right_ after logging in, the JS SDK wouldn't see the user as logged in immediately.

This was causing the initial FB.api('/me/friends') call to die. 

I refactored it a bit to try again every half second. This made it so the friends list would come up after a few tries, once Facebook's JS SDK would finally know that the user had logged it. 

fwiw, 

John
