### PR TITLE
A public function added so a single -selected- id (friend) can be deselected by script.

### DIFF
--- a/jquery.facebook.multifriend.select.js
+++ b/jquery.facebook.multifriend.select.js
@@ -124,6 +124,19 @@
             all_friends.removeClass("selected");
         };
         
+        this.deselectSelectedId = function (id) {
+            $.each(elem.find(".jfmfs-friend.selected"), function (i, friend) {
+                if ($(friend).attr("id") == id) {
+                    $(friend).removeClass("selected");
+                }
+            });
+            // update the count of the total number selected
+            $("#jfmfs-selected-count").html($(".jfmfs-friend.selected").length);
+            //update how many are selected of the maximum
+            var message = settings.labels.max_selected_message.replace("{0}", $(".jfmfs-friend.selected").length).replace("{1}", settings.max_selected);
+            $("#jfmfs-max-selected-wrapper").html(message);
+        };
+        
         // ----------+----------+----------+----------+----------+----------+----------+
         // Private functions
         // ----------+----------+----------+----------+----------+----------+----------+


### PR DESCRIPTION
I implemented this because I had other div displaying the friends I selected through the multi-friend-selector but I also needed to be able to deselect a selection in the multi-friend-selector via these other locations.

So now I can call:
`$("#deselectFriend").live("click", function () {
                var friendSelector = $("#jfmfs-container").data('jfmfs');
                friendSelector.deselect($("#selectedFriendId").text());
            });`
