### PR TITLE
Default value for  first_element_offset_px

### DIFF
--- a/jquery.facebook.multifriend.select.js
+++ b/jquery.facebook.multifriend.select.js
@@ -132,7 +132,7 @@
             all_friends = $(".jfmfs-friend", elem);
             
             // calculate friends per row
-            first_element_offset_px = all_friends.first().offset().top;
+            first_element_offset_px = (all_friends.length == 0) ? 0 : all_friends.first().offset().top;
             for(var i=0, l=all_friends.length; i < l; i++ ) {
                 if($(all_friends[i]).offset().top === first_element_offset_px) {
                     friends_per_row++;


### PR DESCRIPTION
During development with this plugin, I noticed that when all friends were excluded, first_element_offset_px was triggering a javascript error (since array all_friends) was empty. so i just set the offset in that case to be 0.
