### PR TITLE
Added access_token API override option...

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ For example your options might look like this if you want a max of 3 friends sel
 		    }
 		}
 
+* access_token: api access token override in the event that an existing, active session token is available from a server-side login flow.
+
 Events
 ------
 jfmfs.friendload.finished - triggered on the container when the list of friends is finished loading

--- a/jquery.facebook.multifriend.select.js
+++ b/jquery.facebook.multifriend.select.js
@@ -73,8 +73,14 @@
 			preselected_friends_graph = arrayToObjectGraph(settings.pre_selected_friends),
 			excluded_friends_graph = arrayToObjectGraph(settings.exclude_friends),
             all_friends;
-            
-        FB.api('/me/friends?fields=' + settings.friend_fields, function(response) {
+
+        var fbAPIOptions = {};
+        if (options.access_token) {
+            fbAPIOptions['access_token'] = options.access_token;
+        }
+        FB.api('/me/friends?fields=' + settings.friend_fields,
+            fbAPIOptions,
+            function(response) {
             var sortedFriendData = response.data.sort(settings.sorter),
                 preselectedFriends = {},
                 buffer = [],


### PR DESCRIPTION
I am not sure if this is the best way of going about it. I have a server-side FB login flow through which I obtain an access token. I found that the FB.api call the plugin makes is not aware of the session. Perhaps there is a better way of initializing the FB instance to be aware of the access token, but I could not find one. 

I have provided some changes to the code to add an 'access_token' option that can be passed in manually.

If you know of a better way, I am all ears.  
