### PR TITLE
add link to jquery-thingy-picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+Update
+------
+
+@rweng maintains a more generic and up to date fork of this repository at [https://github.com/rweng/jquery-thingy-picker](https://github.com/rweng/jquery-thingy-picker).
+
 ISO New Maintainer
 ------------------
 


### PR DESCRIPTION
Hi Mike,

I as mentioned before, I needed a more generic version of the friend selector. I got to publish it now, though it's still a lot(!) of refinement to do.

However, since the generic version is actively used in a project of mine I will continue supporting it. I'd like to add a link to this repositories Readme for anyone interested. It contains an demo page on heroku with your FB example.

Let me know what you think.
